### PR TITLE
Add root-level requirements.txt for CEBRA pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+# Core numerical & EEG processing
+numpy
+scipy
+mne
+
+# Machine learning / deep learning
+torch>=2.0
+cebra==0.6.0a2
+scikit-learn
+
+# Visualization & utilities (used in notebooks and analysis)
+matplotlib
+seaborn
+tqdm


### PR DESCRIPTION
# Add root-level requirements.txt for CEBRA pipeline

Adds a root-level `requirements.txt` for the CEBRA pipeline.

**Reason:**  
The README instructs `pip install -r requirements.txt`, but the only existing requirements file is inside `PreprocessingPipeline/`.  
Having a root-level file allows users to install dependencies directly from the repo root, as intended.

**Affected files (previously missing imports without root-level requirements):**  
- `prepare_cebra_input.py`
- `preprocessing_functions.py`
- `train_cebra.py`
- `train_cebra_cut_supervised.py`
- `train_cebra_cut_unsupervised.py`
- `cebra-running-notebook-2.ipynb`
- `eeg_preprocessing.ipynb`

**Included core dependencies:**  
- **Numerical & EEG processing:** `numpy`, `scipy`, `mne`  
- **Machine learning / deep learning:** `torch>=2.0`, `cebra==0.6.0a2`, `scikit-learn`  
- **Visualization & utilities:** `matplotlib`, `seaborn`, `tqdm`  

Feedback and suggestions are welcome!
